### PR TITLE
Implement throwErrorOnAssetMissing configuration

### DIFF
--- a/assetrev/config.php
+++ b/assetrev/config.php
@@ -19,4 +19,11 @@ return array(
 
     'assetUrlPrefix' => null,
 
+    // By default, throw an error if the file does not exist within the file
+    // system. This is to make sure no assets are missing on page load.
+    // This option can be set to false which will turn off exceptions and still
+    // include a random cache busting string.
+
+    'throwErrorOnMissingAsset' => true,
+
 );

--- a/assetrev/services/AssetRevService.php
+++ b/assetrev/services/AssetRevService.php
@@ -18,7 +18,8 @@ class AssetRevService extends BaseApplicationComponent
         $revver = new FilenameRev(
             $this->parseEnvironmentString(craft()->config->get('manifestPath', 'assetrev')),
             $this->parseEnvironmentString(craft()->config->get('assetsBasePath', 'assetrev')),
-            $this->parseEnvironmentString(craft()->config->get('assetUrlPrefix', 'assetrev'))
+            $this->parseEnvironmentString(craft()->config->get('assetUrlPrefix', 'assetrev')),
+            $this->parseEnvironmentString(craft()->config->get('throwErrorOnMissingAsset', 'assetrev'))
         );
 
         $revver->setBasePath(CRAFT_BASE_PATH);


### PR DESCRIPTION
We use javascript hot-reloading in development which means the asset
doesn't exist in the file system but is generated on the file by a node
server.

This configuration param will determine if an error is thrown on missing
assets.  By default, it will throw an exception. If set to false, a
cache busting string is still included using a randomString method.

Fixes #9 