### PR TITLE
Point to your other craft3 repository instead of v6 branch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 # CraftCMS Asset Rev / Cache Busting (Craft 2.x)
 [![Build Status](https://travis-ci.org/clubstudioltd/craft-asset-rev.svg?branch=v5)](https://travis-ci.org/clubstudioltd/craft-asset-rev)
 
-**Looking for Craft 3 Support?** [Asset Rev for Craft 3](https://github.com/clubstudioltd/craft-asset-rev/tree/v6)
+**Looking for Craft 3 Support?** [Asset Rev for Craft 3](https://github.com/clubstudioltd/craft3-asset-rev)
 
 A Twig extension for CraftCMS that helps you cache-bust your assets using configurable strategies.
 


### PR DESCRIPTION
Maybe you mean to point to the Craft 3 repository instead of the V6 branch in the Craft 2 repository.