### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/AssetRev.php
+++ b/src/AssetRev.php
@@ -17,7 +17,7 @@ class AssetRev extends Plugin
             'assetRev' => Service::class,
         ]);
 
-        Craft::$app->view->twig->addExtension(new AssetRevTwigExtension);
+        Craft::$app->view->registerTwigExtension(new AssetRevTwigExtension);
     }
 
     protected function createSettingsModel()


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.